### PR TITLE
Use official Rust base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:devel
+FROM rust:1.88-slim
 
-RUN apt-get update && apt-get install -y cargo && cargo install typstyle --locked
+RUN cargo install typstyle --locked
 
-ENV PATH /root/.cargo/bin:$PATH
+ENV PATH=/root/.cargo/bin:$PATH
 
 COPY entrypoint.sh .
 


### PR DESCRIPTION
Apply the recommended bug fix for #8: switch to the official `rust:1.88-slim` base image. See #8 for details.

Minor follow-up: fix a legacy Dockerfile `ENV` syntax that caused a warning.