### PR TITLE
feat: install prebuilt typstyle binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM rust:1.88-slim
+FROM alpine:3.23
 
-RUN cargo install typstyle --locked
-
-ENV PATH=/root/.cargo/bin:$PATH
+ADD --chmod=755 https://github.com/typstyle-rs/typstyle/releases/latest/download/typstyle-x86_64-unknown-linux-musl /usr/local/bin/typstyle
 
 COPY entrypoint.sh .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
 find $INPUT_INPUTS -name "*.typ" | xargs -r typstyle $INPUT_OPTS
 


### PR DESCRIPTION
The action now installs the latest typsyle binary from github releases instead of building from source using cargo. The base image used is now alpine instead of rust since the rust toolchain in not required during runtime of the action.
To not change any functionality of the action, I made it download the latest release as before. A future improvement would be to let the action user specify the typstyle version they want.

closes #10 